### PR TITLE
Fix wrong tab caption that appears when editing documents in swapped tabs

### DIFF
--- a/tabbar.cpp
+++ b/tabbar.cpp
@@ -99,7 +99,10 @@ void TabBar::addEditorTab(Core::IEditor *editor)
 
     m_editors.append(editor);
 
-    connect(document, &Core::IDocument::changed, [this, index, document]() {
+    connect(document, &Core::IDocument::changed, [this, editor, document]() {
+        const int index = m_editors.indexOf(editor);
+        if (index == -1)
+            return;
         QString tabText = document->displayName();
         if (document->isModified())
             tabText += QLatin1Char('*');


### PR DESCRIPTION
Steps to reproduce:

1. Open two files, say 1.txt and 2.txt.
2. Swap tabs on tabbar so the first tab becomes 2.txt followed by 1.txt.
3. Type smth in 2.txt.

Expected behavior: tab caption of 2.txt changes to 2.txt* (with asterisk).
Real behavior: tab caption of 1.txt changes to 2.txt*.

This happens since Core::IDocument::changed signal handler captures tab index used at tab creation. When tabs are reordered by the user, this index becomes invalid but lambda still uses old captured value. I've prepared a simple fix for this issue, please review and apply it.