### PR TITLE
fixed qtcreator 4.2.0 source compatibility

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -67,7 +67,7 @@ void TabbedEditorPlugin::updateStyleToBaseColor()
     QString selectedTabBorderColorQss;
     QString shadowColorQss;
 
-    if(theme->widgetStyle() == Utils::Theme::StyleDefault) {
+    if(theme->preferredStyles().isEmpty()) {
         baseColorQss = getQssStringFromColor(Utils::StyleHelper::baseColor().lighter(130));
         borderColorQss = getQssStringFromColor(Utils::StyleHelper::borderColor());
         highlightColorQss = getQssStringFromColor(Utils::StyleHelper::baseColor());


### PR DESCRIPTION
the plugin was using an outdated function to check if the selected theme was the default one, i'm not 100% sure this fix generates a correct behavior because i don't know the api properly, but at least it does compile on arch linux and the plugin seems to work well with dark themes