### PR TITLE
close modified document without saved will always remove the tab whenever user choose cancel or not save

### DIFF
--- a/tabbar.cpp
+++ b/tabbar.cpp
@@ -136,8 +136,12 @@ void TabBar::closeTab(int index)
     if (index < 0 || index >= m_editors.size())
         return;
 
-    Core::EditorManager::instance()->closeEditor(m_editors.takeAt(index));
-    removeTab(index);
+    // error if user click close button to close a document which is modified and not saved,
+    // this call will defalt call closeEditor with closeEditor(IEditor *editor, bool askAboutModifiedEditors = true)
+    // if user chose "cancel", the Core::EditorManager won't close the editor, TabBar use takeAt will remove the editor from
+    // the container m_editors and call removeTab() to remove from QTabBar
+    Core::EditorManager::instance()->closeEditor(m_editors.value(index));
+
 }
 
 void TabBar::prevTabAction()


### PR DESCRIPTION
when user click close button to close a document which is modified and not saved,there should be a messagebox asking whether to save or not save or cancel .
if user choose cancel ,the document should not be close,but the TabBar remove the tab of the document.

Signed-off-by: foniova <z.liangyi@gmail.com>